### PR TITLE
Fixes a typo in plastitanium window.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -741,7 +741,7 @@
 
 /obj/structure/window/plastitanium
 	name = "plastitanium window"
-	desc = "A durable looking window made of an alloy of of plasma and titanium."
+	desc = "A durable looking window made out of an alloy of plasma and titanium."
 	icon = 'icons/obj/smooth_structures/plastitanium_window.dmi'
 	icon_state = "plastitanium_window"
 	dir = FULLTILE_WINDOW_DIR


### PR DESCRIPTION

# Document the changes in your pull request

Fixes a SINGLE typo in the plastitanium window because I saw it one nuclear emergency round and was like, "I bet I could fix that.........." And then fast forward to today where I thought about it and I'm trying to fix it now :)

# Spriting
no sprites.

# Wiki Documentation

I don't think so.

# Changelog

Fixes a SINGLE typo in the plastitanium window.

:cl:  
spellcheck: fixes a SINGLE typo in the plastitanium window :) /:cl:
